### PR TITLE
Remove the @Blocking annotation from ProductsResource

### DIFF
--- a/code/exercise_005_products_from_the_database/src/main/java/com/lunatech/training/quarkus/ProductsResource.java
+++ b/code/exercise_005_products_from_the_database/src/main/java/com/lunatech/training/quarkus/ProductsResource.java
@@ -2,7 +2,6 @@ package com.lunatech.training.quarkus;
 
 import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
-import io.smallrye.common.annotation.Blocking;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -20,14 +19,12 @@ public class ProductsResource {
     Template details;
 
     @GET
-    @Blocking
     public TemplateInstance products() {
         return catalogue.data("products", Product.listAll());
     }
 
     @GET
     @Path("{productId}")
-    @Blocking
     public TemplateInstance details(@PathParam("productId") Long productId) {
         Product product = Product.findById(productId);
         if(product != null) {

--- a/code/exercise_006_CDI_and_ArC/src/main/java/com/lunatech/training/quarkus/ProductsResource.java
+++ b/code/exercise_006_CDI_and_ArC/src/main/java/com/lunatech/training/quarkus/ProductsResource.java
@@ -2,7 +2,6 @@ package com.lunatech.training.quarkus;
 
 import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
-import io.smallrye.common.annotation.Blocking;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -20,14 +19,12 @@ public class ProductsResource {
     Template details;
 
     @GET
-    @Blocking
     public TemplateInstance products() {
         return catalogue.data("products", Product.listAll());
     }
 
     @GET
     @Path("{productId}")
-    @Blocking
     public TemplateInstance details(@PathParam("productId") Long productId) {
         Product product = Product.findById(productId);
         if(product != null) {

--- a/code/exercise_007_Convert_endpoints_to_JSON/src/main/java/com/lunatech/training/quarkus/ProductsResource.java
+++ b/code/exercise_007_Convert_endpoints_to_JSON/src/main/java/com/lunatech/training/quarkus/ProductsResource.java
@@ -1,7 +1,5 @@
 package com.lunatech.training.quarkus;
 
-import io.smallrye.common.annotation.Blocking;
-
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import java.util.List;
@@ -11,14 +9,12 @@ import java.util.List;
 public class ProductsResource {
 
     @GET
-    @Blocking
     public List<Product> products() {
         return Product.listAll();
     }
 
     @GET
     @Path("{productId}")
-    @Blocking
     public Product details(@PathParam("productId") Long productId) {
         Product product = Product.findById(productId);
         if (product != null) {

--- a/code/exercise_008_Adding_REST_data_Panache/src/main/java/com/lunatech/training/quarkus/ProductsResource.java
+++ b/code/exercise_008_Adding_REST_data_Panache/src/main/java/com/lunatech/training/quarkus/ProductsResource.java
@@ -1,7 +1,5 @@
 package com.lunatech.training.quarkus;
 
-import io.smallrye.common.annotation.Blocking;
-
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import java.util.List;
@@ -11,14 +9,12 @@ import java.util.List;
 public class ProductsResource {
 
     @GET
-    @Blocking
     public List<Product> products() {
         return Product.listAll();
     }
 
     @GET
     @Path("{productId}")
-    @Blocking
     public Product details(@PathParam("productId") Long productId) {
         Product product = Product.findById(productId);
         if (product != null) {

--- a/code/exercise_009_Hook_up_the_React_app/src/main/java/com/lunatech/training/quarkus/ProductsResource.java
+++ b/code/exercise_009_Hook_up_the_React_app/src/main/java/com/lunatech/training/quarkus/ProductsResource.java
@@ -1,7 +1,5 @@
 package com.lunatech.training.quarkus;
 
-import io.smallrye.common.annotation.Blocking;
-
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import java.util.List;
@@ -11,14 +9,12 @@ import java.util.List;
 public class ProductsResource {
 
     @GET
-    @Blocking
     public List<Product> products() {
         return Product.listAll();
     }
 
     @GET
     @Path("{productId}")
-    @Blocking
     public Product details(@PathParam("productId") Long productId) {
         Product product = Product.findById(productId);
         if (product != null) {

--- a/code/exercise_010_Validation_and_PUT/src/main/java/com/lunatech/training/quarkus/ProductsResource.java
+++ b/code/exercise_010_Validation_and_PUT/src/main/java/com/lunatech/training/quarkus/ProductsResource.java
@@ -1,7 +1,5 @@
 package com.lunatech.training.quarkus;
 
-import io.smallrye.common.annotation.Blocking;
-
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import jakarta.ws.rs.*;
@@ -14,14 +12,12 @@ import java.util.List;
 public class ProductsResource {
 
     @GET
-    @Blocking
     public List<Product> products() {
         return Product.listAll();
     }
 
     @GET
     @Path("{productId}")
-    @Blocking
     public Product details(@PathParam("productId") Long productId) {
         Product product = Product.findById(productId);
         if (product != null) {


### PR DESCRIPTION
From a teaching point of view it makes sense to discuss the `@Blocking` annotation when we come to the "Reactive" part of the course around Exercise 11. For the earlier non-reactive exercises, introducing the `@Blocking` annotation risks being just noise.