### PR TITLE
fix: product pkey conflict caused by import.sql

### DIFF
--- a/code/exercise_008_Adding_REST_data_Panache/src/main/resources/import.sql
+++ b/code/exercise_008_Adding_REST_data_Panache/src/main/resources/import.sql
@@ -1,7 +1,8 @@
-INSERT into Product (id, name, description, price) VALUES (1, 'Chair', 'A metal frame chair, with oak seat', 59.95);
-INSERT into Product (id, name, description, price) VALUES (2, 'Dinner Table', 'Sturdy oak Table', 200);
-INSERT into Product (id, name, description, price) VALUES (3, 'Coffee Table', 'An oak coffee Table', 120);
-INSERT into Product (id, name, description, price) VALUES (4, 'Side Table', 'A Nice little oak side table', 80);
-INSERT into Product (id, name, description, price) VALUES (5, 'Mirror', 'A round mirror with oak frame', 80);
-INSERT into Product (id, name, description, price) VALUES (6, 'Lamp', 'A light that shines', 45);
-INSERT into Product (id, name, description, price) VALUES (7, 'Carpet', 'Soft carpet', 39.95);
+ALTER SEQUENCE Product_SEQ INCREMENT BY 1;
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Chair', 'A metal frame chair, with oak seat', 59.95);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Dinner Table', 'Sturdy oak Table', 200);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Coffee Table', 'An oak coffee Table', 120);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Side Table', 'A Nice little oak side table', 80);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Mirror', 'A round mirror with oak frame', 80);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Lamp', 'A light that shines', 45);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Carpet', 'Soft carpet', 39.95);

--- a/code/exercise_009_Hook_up_the_React_app/src/main/resources/import.sql
+++ b/code/exercise_009_Hook_up_the_React_app/src/main/resources/import.sql
@@ -1,7 +1,8 @@
-INSERT into Product (id, name, description, price) VALUES (1, 'Chair', 'A metal frame chair, with oak seat', 59.95);
-INSERT into Product (id, name, description, price) VALUES (2, 'Dinner Table', 'Sturdy oak Table', 200);
-INSERT into Product (id, name, description, price) VALUES (3, 'Coffee Table', 'An oak coffee Table', 120);
-INSERT into Product (id, name, description, price) VALUES (4, 'Side Table', 'A Nice little oak side table', 80);
-INSERT into Product (id, name, description, price) VALUES (5, 'Mirror', 'A round mirror with oak frame', 80);
-INSERT into Product (id, name, description, price) VALUES (6, 'Lamp', 'A light that shines', 45);
-INSERT into Product (id, name, description, price) VALUES (7, 'Carpet', 'Soft carpet', 39.95);
+ALTER SEQUENCE Product_SEQ INCREMENT BY 1;
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Chair', 'A metal frame chair, with oak seat', 59.95);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Dinner Table', 'Sturdy oak Table', 200);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Coffee Table', 'An oak coffee Table', 120);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Side Table', 'A Nice little oak side table', 80);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Mirror', 'A round mirror with oak frame', 80);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Lamp', 'A light that shines', 45);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Carpet', 'Soft carpet', 39.95);

--- a/code/exercise_010_Validation_and_PUT/src/main/resources/import.sql
+++ b/code/exercise_010_Validation_and_PUT/src/main/resources/import.sql
@@ -1,7 +1,8 @@
-INSERT into Product (id, name, description, price) VALUES (1, 'Chair', 'A metal frame chair, with oak seat', 59.95);
-INSERT into Product (id, name, description, price) VALUES (2, 'Dinner Table', 'Sturdy oak Table', 200);
-INSERT into Product (id, name, description, price) VALUES (3, 'Coffee Table', 'An oak coffee Table', 120);
-INSERT into Product (id, name, description, price) VALUES (4, 'Side Table', 'A Nice little oak side table', 80);
-INSERT into Product (id, name, description, price) VALUES (5, 'Mirror', 'A round mirror with oak frame', 80);
-INSERT into Product (id, name, description, price) VALUES (6, 'Lamp', 'A light that shines', 45);
-INSERT into Product (id, name, description, price) VALUES (7, 'Carpet', 'Soft carpet', 39.95);
+ALTER SEQUENCE Product_SEQ INCREMENT BY 1;
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Chair', 'A metal frame chair, with oak seat', 59.95);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Dinner Table', 'Sturdy oak Table', 200);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Coffee Table', 'An oak coffee Table', 120);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Side Table', 'A Nice little oak side table', 80);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Mirror', 'A round mirror with oak frame', 80);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Lamp', 'A light that shines', 45);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Carpet', 'Soft carpet', 39.95);

--- a/code/exercise_011_Going_Reactive/src/main/resources/import.sql
+++ b/code/exercise_011_Going_Reactive/src/main/resources/import.sql
@@ -1,7 +1,8 @@
-INSERT into Product (id, name, description, price) VALUES (1, 'Chair', 'A metal frame chair, with oak seat', 59.95);
-INSERT into Product (id, name, description, price) VALUES (2, 'Dinner Table', 'Sturdy oak Table', 200);
-INSERT into Product (id, name, description, price) VALUES (3, 'Coffee Table', 'An oak coffee Table', 120);
-INSERT into Product (id, name, description, price) VALUES (4, 'Side Table', 'A Nice little oak side table', 80);
-INSERT into Product (id, name, description, price) VALUES (5, 'Mirror', 'A round mirror with oak frame', 80);
-INSERT into Product (id, name, description, price) VALUES (6, 'Lamp', 'A light that shines', 45);
-INSERT into Product (id, name, description, price) VALUES (7, 'Carpet', 'Soft carpet', 39.95);
+ALTER SEQUENCE Product_SEQ INCREMENT BY 1;
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Chair', 'A metal frame chair, with oak seat', 59.95);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Dinner Table', 'Sturdy oak Table', 200);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Coffee Table', 'An oak coffee Table', 120);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Side Table', 'A Nice little oak side table', 80);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Mirror', 'A round mirror with oak frame', 80);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Lamp', 'A light that shines', 45);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Carpet', 'Soft carpet', 39.95);

--- a/code/exercise_012_Reactive_search_endpoint/src/main/resources/import.sql
+++ b/code/exercise_012_Reactive_search_endpoint/src/main/resources/import.sql
@@ -1,7 +1,8 @@
-INSERT into Product (id, name, description, price) VALUES (1, 'Chair', 'A metal frame chair, with oak seat', 59.95);
-INSERT into Product (id, name, description, price) VALUES (2, 'Dinner Table', 'Sturdy oak Table', 200);
-INSERT into Product (id, name, description, price) VALUES (3, 'Coffee Table', 'An oak coffee Table', 120);
-INSERT into Product (id, name, description, price) VALUES (4, 'Side Table', 'A Nice little oak side table', 80);
-INSERT into Product (id, name, description, price) VALUES (5, 'Mirror', 'A round mirror with oak frame', 80);
-INSERT into Product (id, name, description, price) VALUES (6, 'Lamp', 'A light that shines', 45);
-INSERT into Product (id, name, description, price) VALUES (7, 'Carpet', 'Soft carpet', 39.95);
+ALTER SEQUENCE Product_SEQ INCREMENT BY 1;
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Chair', 'A metal frame chair, with oak seat', 59.95);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Dinner Table', 'Sturdy oak Table', 200);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Coffee Table', 'An oak coffee Table', 120);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Side Table', 'A Nice little oak side table', 80);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Mirror', 'A round mirror with oak frame', 80);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Lamp', 'A light that shines', 45);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Carpet', 'Soft carpet', 39.95);

--- a/code/exercise_013_Listen_and_Notify/src/main/resources/import.sql
+++ b/code/exercise_013_Listen_and_Notify/src/main/resources/import.sql
@@ -1,7 +1,8 @@
-INSERT into Product (id, name, description, price) VALUES (1, 'Chair', 'A metal frame chair, with oak seat', 59.95);
-INSERT into Product (id, name, description, price) VALUES (2, 'Dinner Table', 'Sturdy oak Table', 200);
-INSERT into Product (id, name, description, price) VALUES (3, 'Coffee Table', 'An oak coffee Table', 120);
-INSERT into Product (id, name, description, price) VALUES (4, 'Side Table', 'A Nice little oak side table', 80);
-INSERT into Product (id, name, description, price) VALUES (5, 'Mirror', 'A round mirror with oak frame', 80);
-INSERT into Product (id, name, description, price) VALUES (6, 'Lamp', 'A light that shines', 45);
-INSERT into Product (id, name, description, price) VALUES (7, 'Carpet', 'Soft carpet', 39.95);
+ALTER SEQUENCE Product_SEQ INCREMENT BY 1;
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Chair', 'A metal frame chair, with oak seat', 59.95);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Dinner Table', 'Sturdy oak Table', 200);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Coffee Table', 'An oak coffee Table', 120);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Side Table', 'A Nice little oak side table', 80);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Mirror', 'A round mirror with oak frame', 80);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Lamp', 'A light that shines', 45);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Carpet', 'Soft carpet', 39.95);

--- a/code/exercise_014_Internal_Channels/README.md
+++ b/code/exercise_014_Internal_Channels/README.md
@@ -37,7 +37,7 @@ public class PriceUpdateStreams {
 }
 ```
 
-* Implement the method `public Multi<PriceUpdate> generate()` on the `PriceUpdateStreams` class, and make it return a `Multi` that emits a `PriceUpdate` item *every five seconds*, using a random price between 0 and 100, for each of the products in our database (You can hardcode the product IDs 1 to 7 inclusive) .
+* Implement the method `public Multi<PriceUpdate> generate()` on the `PriceUpdateStreams` class, and make it return a `Multi` that emits a `PriceUpdate` item *every five seconds*, using a random price between 0 and 100, for each of the products in our database (You can hardcode the product IDs - use `curl localhost:8080/products` to discover the product IDs saved in the database) .
   
   Tip, look at the `Multi.createFrom().ticks()` method!
   Note that the `print` method has an `@Incoming` annotation that matches the `@Outgoing` from the `generate` method. Running the application should print seven lines to the console every five seconds, each line being a price update for a product. Run the app to try this :)

--- a/code/exercise_014_Internal_Channels/src/main/resources/import.sql
+++ b/code/exercise_014_Internal_Channels/src/main/resources/import.sql
@@ -1,7 +1,8 @@
-INSERT into Product (id, name, description, price) VALUES (1, 'Chair', 'A metal frame chair, with oak seat', 59.95);
-INSERT into Product (id, name, description, price) VALUES (2, 'Dinner Table', 'Sturdy oak Table', 200);
-INSERT into Product (id, name, description, price) VALUES (3, 'Coffee Table', 'An oak coffee Table', 120);
-INSERT into Product (id, name, description, price) VALUES (4, 'Side Table', 'A Nice little oak side table', 80);
-INSERT into Product (id, name, description, price) VALUES (5, 'Mirror', 'A round mirror with oak frame', 80);
-INSERT into Product (id, name, description, price) VALUES (6, 'Lamp', 'A light that shines', 45);
-INSERT into Product (id, name, description, price) VALUES (7, 'Carpet', 'Soft carpet', 39.95);
+ALTER SEQUENCE Product_SEQ INCREMENT BY 1;
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Chair', 'A metal frame chair, with oak seat', 59.95);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Dinner Table', 'Sturdy oak Table', 200);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Coffee Table', 'An oak coffee Table', 120);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Side Table', 'A Nice little oak side table', 80);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Mirror', 'A round mirror with oak frame', 80);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Lamp', 'A light that shines', 45);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Carpet', 'Soft carpet', 39.95);

--- a/code/exercise_015_Connecting_to_Kafka/src/main/resources/import.sql
+++ b/code/exercise_015_Connecting_to_Kafka/src/main/resources/import.sql
@@ -1,7 +1,8 @@
-INSERT into Product (id, name, description, price) VALUES (1, 'Chair', 'A metal frame chair, with oak seat', 59.95);
-INSERT into Product (id, name, description, price) VALUES (2, 'Dinner Table', 'Sturdy oak Table', 200);
-INSERT into Product (id, name, description, price) VALUES (3, 'Coffee Table', 'An oak coffee Table', 120);
-INSERT into Product (id, name, description, price) VALUES (4, 'Side Table', 'A Nice little oak side table', 80);
-INSERT into Product (id, name, description, price) VALUES (5, 'Mirror', 'A round mirror with oak frame', 80);
-INSERT into Product (id, name, description, price) VALUES (6, 'Lamp', 'A light that shines', 45);
-INSERT into Product (id, name, description, price) VALUES (7, 'Carpet', 'Soft carpet', 39.95);
+ALTER SEQUENCE Product_SEQ INCREMENT BY 1;
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Chair', 'A metal frame chair, with oak seat', 59.95);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Dinner Table', 'Sturdy oak Table', 200);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Coffee Table', 'An oak coffee Table', 120);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Side Table', 'A Nice little oak side table', 80);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Mirror', 'A round mirror with oak frame', 80);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Lamp', 'A light that shines', 45);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Carpet', 'Soft carpet', 39.95);

--- a/code/exercise_016_Dead_Letter_Queue_and_Stream_filtering/src/main/resources/import.sql
+++ b/code/exercise_016_Dead_Letter_Queue_and_Stream_filtering/src/main/resources/import.sql
@@ -1,7 +1,8 @@
-INSERT into Product (id, name, description, price) VALUES (1, 'Chair', 'A metal frame chair, with oak seat', 59.95);
-INSERT into Product (id, name, description, price) VALUES (2, 'Dinner Table', 'Sturdy oak Table', 200);
-INSERT into Product (id, name, description, price) VALUES (3, 'Coffee Table', 'An oak coffee Table', 120);
-INSERT into Product (id, name, description, price) VALUES (4, 'Side Table', 'A Nice little oak side table', 80);
-INSERT into Product (id, name, description, price) VALUES (5, 'Mirror', 'A round mirror with oak frame', 80);
-INSERT into Product (id, name, description, price) VALUES (6, 'Lamp', 'A light that shines', 45);
-INSERT into Product (id, name, description, price) VALUES (7, 'Carpet', 'Soft carpet', 39.95);
+ALTER SEQUENCE Product_SEQ INCREMENT BY 1;
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Chair', 'A metal frame chair, with oak seat', 59.95);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Dinner Table', 'Sturdy oak Table', 200);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Coffee Table', 'An oak coffee Table', 120);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Side Table', 'A Nice little oak side table', 80);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Mirror', 'A round mirror with oak frame', 80);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Lamp', 'A light that shines', 45);
+INSERT into Product (id, name, description, price) VALUES (nextval('Product_SEQ'), 'Carpet', 'Soft carpet', 39.95);


### PR DESCRIPTION
The Product PanacheEntity use a generated sequence, but manually adding products with hardcoded id in import.sql bypass the sequence increment, causing a conflict when POSTing a product from the swagger.
I managed to finish the course with a workaround, using `nextval` and altering the sequence to keep simple ids (1,2,3..).
